### PR TITLE
Add setting Window in Page creation for the Content

### DIFF
--- a/Graphite/Page.cs
+++ b/Graphite/Page.cs
@@ -21,6 +21,7 @@ namespace Graphite
             Height = height;
 
             Content = content;
+            Content.Window = window;
             Content.Bounds = new Rectangle(0, 0, width, height);
             Content.LayoutControls();
         }


### PR DESCRIPTION
Because the Content.Window was not set when creating a new Page, Window was left null, so you couldn't use things like `RedrawWithChange()` at all inside the Page.

This small fix fixes that, so you can change something in your page and have it redrawn correctly :)